### PR TITLE
docs: add infrastructure plan

### DIFF
--- a/docs/ops/Infrastructure.md
+++ b/docs/ops/Infrastructure.md
@@ -1,0 +1,23 @@
+# Infrastructure Plan
+
+## Perimeter Fencing
+- 6 ft perimeter fencing with buried dig barriers and double-gated entry points.
+- Install according to county building codes and zoning permits; inspect quarterly for damage.
+
+## Water Sourcing & Storage
+- Municipal hookup backed by a well or hauled water contract.
+- On-site storage tanks sized for 72 hours of demand with treatment logs meeting state water quality standards.
+
+## Fire Safety
+- Maintain 30 ft defensible space around structures and clear brush seasonally.
+- Equip facility with hydrants or cistern access, ABC extinguishers, and staff training; run annual fire drills with the local department.
+
+## Emergency Quarantine
+- Dedicated isolation kennels with negative airflow and separate waste lines.
+- Stock PPE and disinfection supplies; coordinate entry/exit routes to prevent cross-contamination.
+
+## Dependency Map for Large-Scale Incidents
+- **Veterinary partners:** County vet hospital, mobile triage units, university extension clinics.
+- **Local services:** County animal control, emergency management office, fire department, and water utility.
+
+All facilities must comply with state and county permitting, health, and charitable solicitation requirements noted in the [Nonprofit Roadmap](../legal/NonprofitRoadmap.md).


### PR DESCRIPTION
## Summary
- add infrastructure plan outlining fencing, water, fire safety, quarantine, and partner dependencies
- link compliance needs to nonprofit roadmap

## Testing
- `npm test` (fails: could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adb4968ef4832e9ca19327fa7c9831