### PR TITLE
Add advanced adoption metrics

### DIFF
--- a/analytics/KPIs.md
+++ b/analytics/KPIs.md
@@ -1,8 +1,8 @@
 # KPIs
 
-- **Live:** intakes, adoptions, live population, sanctuary count.  
-- **Flow:** days-to-adoption, % returns (<5%), foster capacity utilization.  
-- **Behavior:** sessions/week per dog, success score trend, incident count.  
-- **Medical:** cost/dog, spay-neuter completion %.  
-- **Fundraising:** MRR (monthly recurring), CAC by campaign, LTV proxy.  
+- **Live:** intakes, adoptions, live population, sanctuary count.
+- **Flow:** days-to-adoption, % returns (<5%), foster capacity utilization, family stay completion rate, post-adoption retention.
+- **Behavior:** sessions/week per dog, success score trend, incident count, therapy-dog integration success.
+- **Medical:** cost/dog, spay-neuter completion %.
+- **Fundraising:** MRR (monthly recurring), CAC by campaign, LTV proxy.
 - **Media:** reach, conversion to foster/donate.

--- a/analytics/queries.sql
+++ b/analytics/queries.sql
@@ -12,3 +12,27 @@ SELECT
   PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY a.adoption_date - n.intake_date) AS median_days
 FROM adoptions a
 JOIN animals n USING (animal_id);
+
+-- Example: Family stay completion rate
+SELECT
+  DATE_TRUNC('month', start_date) AS month,
+  SUM(CASE WHEN completed_date IS NOT NULL THEN 1 ELSE 0 END)::float / NULLIF(COUNT(*),0) AS completion_rate
+FROM family_stays
+GROUP BY 1
+ORDER BY 1;
+
+-- Example: Post-adoption retention at 6 months
+SELECT
+  DATE_TRUNC('month', adoption_date) AS month,
+  SUM(CASE WHEN return_date IS NULL OR return_date > adoption_date + INTERVAL '6 months' THEN 1 ELSE 0 END)::float / NULLIF(COUNT(*),0) AS retention_6m
+FROM adoptions
+GROUP BY 1
+ORDER BY 1;
+
+-- Example: Therapy-dog integration success rate
+SELECT
+  DATE_TRUNC('month', integration_date) AS month,
+  SUM(CASE WHEN successful THEN 1 ELSE 0 END)::float / NULLIF(COUNT(*),0) AS success_rate
+FROM therapy_dog_integrations
+GROUP BY 1
+ORDER BY 1;


### PR DESCRIPTION
## Summary
- Extend KPIs with family stay completion, post-adoption retention, and therapy-dog integration success
- Provide SQL examples to compute the new metrics

## Testing
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af2f438f84832eaea1ca4fae06d2ef