### PR TITLE
Add disaster evacuation plan and cross-reference

### DIFF
--- a/docs/ops/DisasterEvacuation.md
+++ b/docs/ops/DisasterEvacuation.md
@@ -1,0 +1,21 @@
+# Disaster Evacuation Plan
+
+## Wildfire
+- Trigger: nearby fire within 10 miles or official evacuation order.
+- Routes: North gate to County Road 12; secondary route via River Road if blocked.
+- Staging Area: Fairgrounds parking lot; coordinate with fire department for animal trailers.
+- Supplies: portable crates, medical kits, water, and feed loaded onto trailers.
+
+## Tsunami
+- Trigger: tsunami warning after coastal quake or siren activation.
+- Routes: Primary eastward along Highway 7 to hilltop shelter; alternative via Farm Lane to State Route 22.
+- Staging Area: Hilltop Community Center with pens on the grassy lot.
+- Steps: Secure animals in transport kennels, log headcount, and move in convoy.
+
+## Flood
+- Trigger: river crest forecast to exceed flood stage or severe storm alert.
+- Routes: Evacuate south to Ridge Road; alternate to elevated gravel quarry.
+- Staging Area: County emergency berm; use sandbagging equipment for temporary pens.
+- Preparations: Preload trucks with hay, feed, bedding, and map water rescue contacts.
+
+Review and update this plan annually and after each drill.

--- a/docs/ops/Infrastructure.md
+++ b/docs/ops/Infrastructure.md
@@ -22,5 +22,7 @@
 
 ## Land Stewardship
 - Follow [Land Stewardship guidelines](LandStewardship.md) for manure composting, stormwater controls, and wildlife-friendly features.
+ 
+See the [Disaster Evacuation Plan](DisasterEvacuation.md) for wildfire, tsunami, and flood evacuation routes and staging areas.
 
 All facilities must comply with state and county permitting, health, and charitable solicitation requirements noted in the [Nonprofit Roadmap](../legal/NonprofitRoadmap.md).


### PR DESCRIPTION
## Summary
- Document wildfire, tsunami, and flood evacuation procedures with routes and staging areas.
- Link infrastructure guidance to the new disaster evacuation plan.

## Testing
- `pytest`
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68af3a511be4832e9b4de890a1700423