### PR TITLE
Add volunteer program guide

### DIFF
--- a/people/VolunteerProgram.md
+++ b/people/VolunteerProgram.md
@@ -1,0 +1,33 @@
+# Volunteer Program
+
+## Roles
+- **Kennel Care:** cleaning, feeding, and daily welfare checks.
+- **Behavior Support:** assist trainers during sessions and enrichments.
+- **Outreach & Events:** represent the sanctuary at tabling events and community days.
+- **Records & Data:** enter notes into the CRM and maintain volunteer logs.
+
+## Onboarding
+- Submit application and interview with Volunteer Coordinator.
+- Attend orientation covering safety briefings and the [Operations Handbook](../docs/ops/Handbook.md).
+- Shadow experienced volunteers before independent shifts.
+
+## Training Levels
+- **L1 – Basic Handling:** supervised kennel care and enrichment prep.
+- **L2 – Independent Handling:** solo shift eligibility and intake support.
+- **L3 – Behavior Team:** advanced rehab work and foster coaching.
+
+## Retention Strategies
+- Regular feedback sessions and clear shift scheduling.
+- Recognition milestones at 50 and 100 hours.
+- Paths to higher training levels and leadership roles.
+- Social gatherings and cross-training opportunities.
+
+## Liability Waivers
+- All volunteers sign a liability waiver during onboarding; copies kept on file.
+- Waiver covers animal-related risks, property usage, and medical consent.
+- Adapt the [MOU Template](../templates/MOU_Template.md) for group volunteer agreements.
+
+## Resources & Templates
+- Recruitment outreach: [Email Outreach](../templates/EmailOutreach.md).
+- Announcements and calls for volunteers: [Press Release](../templates/PressRelease.md).
+- Detailed SOPs: see the [Operations Handbook](../docs/ops/Handbook.md).


### PR DESCRIPTION
## Summary
- add volunteer program overview covering roles, onboarding, training tiers, retention, and waivers
- link to operations handbook for SOPs
- reference outreach, MOU, and press release templates for volunteer resources

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af3a939448832e882f7d8d2283705f