### PR TITLE
docs: add tech integration and privacy details

### DIFF
--- a/docs/programs/TherapyDogIntegration.md
+++ b/docs/programs/TherapyDogIntegration.md
@@ -12,6 +12,12 @@
 - Communication drills using visual supports and AAC devices.
 - Family practice visits transitioning to community outings.
 
+## Technology Integration & Privacy
+- Sensor-assisted progress tracking through wearable heart-rate bands or pressure-sensitive leashes, with readings piped into Snowflake for long-term analysis.
+- Remote session options via secure video conferencing and companion apps so families can participate from home or school.
+- Integration with AAC tools like Proloquo2Go, Tobii Dynavox eye-gaze devices, or LAMP Words for Life; usage logs can upload to Snowflake to tailor interventions.
+- Privacy safeguards including explicit consent for data collection, anonymized IDs within Snowflake, and opt-out controls for neurodivergent participants.
+
 ## Staffing Needs
 - Program director overseeing curriculum and clinical standards.
 - Certified therapy dog trainer to pair and prep dogs for sessions.


### PR DESCRIPTION
## Summary
- expand Therapy Dog Integration Center doc with sensor-based tracking, remote session options, AAC data flows to Snowflake, and privacy safeguards

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b34d217ec0832e9a5a415ac876d517