### PR TITLE
docs: add AI pipeline roadmap

### DIFF
--- a/roadmap/AIPipeline.md
+++ b/roadmap/AIPipeline.md
@@ -1,0 +1,23 @@
+# AI Pipeline Roadmap
+
+## Milestones
+
+### Sensor Procurement
+- **Dependencies:** Vendor sourcing, finalized hardware specifications, budget approval.
+- **Estimated Timeline:** Month 1.
+- **Resource Requirements:** $5k hardware budget; procurement lead (0.2 FTE).
+
+### Data Ingestion Prototype
+- **Dependencies:** Configured sensors, edge firmware, Snowflake dev account.
+- **Estimated Timeline:** Months 2–3.
+- **Resource Requirements:** Data engineer (0.5 FTE); firmware developer (0.25 FTE); Snowflake dev environment.
+
+### Interactive Portal MVP
+- **Dependencies:** Ingestion API, UI framework, authentication service.
+- **Estimated Timeline:** Months 4–5.
+- **Resource Requirements:** Full-stack developer (1 FTE); UX designer (0.5 FTE); $1k hosting budget.
+
+### Full Deployment
+- **Dependencies:** Stable portal, scaled data pipeline, QA sign-off.
+- **Estimated Timeline:** Month 6 and beyond.
+- **Resource Requirements:** Ops engineer (0.5 FTE); training materials; $2k monthly cloud budget.


### PR DESCRIPTION
## Summary
- add AI Pipeline roadmap outlining sensor procurement, ingestion prototype, portal MVP, and full deployment milestones

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '.../package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b3647b666c832e8c6c804daaa1859c